### PR TITLE
Theme inactive selections

### DIFF
--- a/mrblib/window.rb
+++ b/mrblib/window.rb
@@ -190,6 +190,14 @@ module Mrbmacs
       end
       @sci.sci_set_sel_fore(true, theme.background_color)
       @sci.sci_set_sel_back(true, theme.foreground_color)
+      @sci.sci_set_element_colour(
+        Scintilla::SC_ELEMENT_SELECTION_INACTIVE_TEXT,
+        theme.background_color | 0xff000000
+      )
+      @sci.sci_set_element_colour(
+        Scintilla::SC_ELEMENT_SELECTION_INACTIVE_BACK,
+        theme.foreground_color | 0xff000000
+      )
     end
 
     def apply_theme(theme)

--- a/test/frame.rb
+++ b/test/frame.rb
@@ -7,5 +7,13 @@ assert('apply_theme') do
   theme = Mrbmacs::SolarizedDarkTheme.new
   frame = Mrbmacs::TestSupport::Frame.new(nil)
   frame.apply_theme(theme)
-  assert_equal Scintilla::SCI_SETSELBACK, frame.view_win.messages.pop
+  assert_equal(
+    [
+      Scintilla::SCI_SETSELFORE,
+      Scintilla::SCI_SETSELBACK,
+      Scintilla::SCI_SETELEMENTCOLOUR,
+      Scintilla::SCI_SETELEMENTCOLOUR
+    ],
+    frame.view_win.messages.last(4)
+  )
 end

--- a/test/window.rb
+++ b/test/window.rb
@@ -2,7 +2,15 @@ assert('apply_theme') do
   app = Mrbmacs::TestSupport::Application.new
   edit_win = app.frame.edit_win
   edit_win.apply_theme(app.theme)
-  assert_equal(Scintilla::SCI_SETSELBACK, app.frame.view_win.messages.pop)
+  assert_equal(
+    [
+      Scintilla::SCI_SETSELFORE,
+      Scintilla::SCI_SETSELBACK,
+      Scintilla::SCI_SETELEMENTCOLOUR,
+      Scintilla::SCI_SETELEMENTCOLOUR
+    ],
+    app.frame.view_win.messages.last(4)
+  )
 end
 
 assert('set_marign') do


### PR DESCRIPTION
## Summary

- apply theme colours to inactive selection text and background
- keep the existing active selection configuration unchanged
- update theme application tests for the additional Scintilla messages

## Why

Incremental search displays the current match as a normal Scintilla selection. Cocoa and GTK move keyboard focus to their search input while searching, so the editor selection becomes inactive and falls back to a platform-defined colour. On macOS this produced a bright selection that was difficult to read with dark themes.

The inactive selection now uses the same foreground/background inversion as the active selection. Element colours include an opaque alpha channel as required by Scintilla.

## Impact

- Cocoa and GTK search matches remain readable while the search input has focus
- curses and Termbox active selection rendering remains unchanged
- other inactive selections use the theme's high-contrast selection colours

## Validation

- `rake clean test`
- 1913 OK, 0 failures, 9 skipped
- bintest: 100 OK
- `git diff --check`
